### PR TITLE
Configurable WellFormed NoBidResponse

### DIFF
--- a/app/shared/com/ortb/demadSidePlatforms/DemandSidePlatformSimulatorServiceApiController.scala
+++ b/app/shared/com/ortb/demadSidePlatforms/DemandSidePlatformSimulatorServiceApiController.scala
@@ -50,7 +50,12 @@ class DemandSidePlatformSimulatorServiceApiController @Inject()(
       val dspBidResponseModel = maybeDemandSidePlatformBidResponseModel.get
       val bidResponseJsonTry =
         Try({
-          throw new Exception("Hello")
+          demandSidePlatformConfiguration
+            .noBiddingResponseConfig
+            .performTechnicalErrorOnDsp
+            .contains(demandSideId)
+            .dosOnTrue(() => throw new Exception("A sample error for testing well-formed no bid response."))
+
           dspBidResponseModel
             .bidResponseWrapper
             .bidResponse

--- a/app/shared/com/ortb/model/config/DemandSidePlatformNoBiddingResponseConfigurationModel.scala
+++ b/app/shared/com/ortb/model/config/DemandSidePlatformNoBiddingResponseConfigurationModel.scala
@@ -2,5 +2,6 @@ package shared.com.ortb.model.config
 
 case class DemandSidePlatformNoBiddingResponseConfigurationModel(
   isWellFormedBidRequest : Boolean,
+  performTechnicalErrorOnDsp : Array[Int],
   wellFormedBidRequestSample : DemandSidePlatformWellFormedBidRequestSampleModel
 )

--- a/app/shared/com/ortb/routes/router/DemandSidePlatformServiceRouter.scala
+++ b/app/shared/com/ortb/routes/router/DemandSidePlatformServiceRouter.scala
@@ -17,9 +17,9 @@ class DemandSidePlatformServiceRouter @Inject()(
 
   override def routes : Routes = {
     try {
-      case GET(p"/serviceName") | GET(p"/") | POST(p"/") | HEAD(p"/") =>
+      case GET(p"/serviceName") | GET(p"/service-name") | GET(p"/") | POST(p"/") | HEAD(p"/") =>
         controller.getServiceName()
-      case POST(p"/makeBidRequst") =>
+      case POST(p"/makeBidRequest") | POST(p"/make-bid-requst") =>
         controller.makeBidRequest()
 
     } catch {

--- a/conf/configuration.json
+++ b/conf/configuration.json
@@ -6,7 +6,10 @@
     "isUseDefaultDomainForAll": true,
     "demandSidePlatformConfiguration": {
       "noBiddingResponseConfig": {
-        "isWellFormedBidRequest": false,
+        "isWellFormedBidRequest": true,
+        "performTechnicalErrorOnDsp": [
+          1
+        ],
         "wellFormedBidRequestSample": {
           "id": "",
           "seatbid": [],


### PR DESCRIPTION
# Configurable WellFormed NoBidResponse
- Added configurable well formed no bid response.
- new routing added
   `case GET(p"/serviceName") | GET(p"/service-name") | GET(p"/") | POST(p"/") | HEAD(p"/") =>`
   `case POST(p"/makeBidRequest") | POST(p"/make-bid-requst") =>`

# Bid Request

## Url
http://localhost:9000/services/v1/dspService/make-bid-requst
HTTP Method : POST
Body raw
```json
{
    "id": "_",
    "at": 1,
    "cur": [
      "USD"
    ],
    "imp": [
      {
        "id": "1",
        "bidfloor": 0.05,
        "banner": {
          "h": 500,
          "w": 600,
          "pos": 0
        }
      }
    ],
    "site": {
      "id": "102855",
      "cat": [
        "IAB3-1"
      ],
      "domain": "www.foobar.com",
      "page": "http://www.foobar.com/1234.html ",
      "publisher": {
        "id": "1",
        "name": "Alim Advertise Server",
        "cat": [
          "IAB3-1"
        ],
        "domain": "foobar.com"
      }
    },
    "device": {
      "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13 (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2",
      "ip": "123.145.167.10"
    },
    "user": {
      "id": "55816b39711f9b5acf3b90e313ed29e51665623f"
    }
  }
```

# Bid Response
```json
{
    "id": "static : BidResponse Id",
    "seatbid": [
        {
            "bid": [
                {
                    "id": "static:bidId",
                    "impid": "1",
                    "price": 0.15311558703184022,
                    "adid": "-1",
                    "nurl": "http://localhost/services/v1/adserver/win-notice/impression/1",
                    "adm": "adm win-notice markup, optional and should be ignored.",
                    "adomain": [
                        "Advertiser blocked domains list",
                        "Sample-Site-blocked.com",
                        "Sample-Site2-blocked.com",
                        "Sample-Site3-blocked.com"
                    ],
                    "iurl": "iurl : uncached image link",
                    "cid": "static: CampaignId",
                    "cat": [
                        "static: categoryId1",
                        "static: categoryId2"
                    ],
                    "dealid": "static: dealId",
                    "h": 500,
                    "w": 600
                }
            ],
            "seat": "SeatBidID/DSP ID : 1",
            "group": null
        }
    ],
    "bidid": null,
    "cur": "USD",
    "nbr": 0
}
```

# Well-formed No Bid Response
```json
{
    "id": "",
    "seatbid": [],
    "nbr": 0
}
```

# Sample Gif
 ![wellformed-bid-response](https://user-images.githubusercontent.com/4561204/83286616-0c680780-a202-11ea-9dac-67960d2cb1a3.gif)
